### PR TITLE
Fix two small bugs

### DIFF
--- a/src/zigcc.nim
+++ b/src/zigcc.nim
@@ -1,2 +1,3 @@
-import os, strutils
-discard execShellCmd "zig cc " & commandLineParams().join(" ")
+import zigcc/utils
+
+callZig("cc")

--- a/src/zigcc/utils.nim
+++ b/src/zigcc/utils.nim
@@ -1,0 +1,18 @@
+import os, osproc
+export os, osproc
+
+template callZig*(zigCmd: string) =
+  # Set the zig compiler to call and append args
+  var args = @[zigCmd]
+  args &= commandLineParams()
+  # Start process
+  let process = startProcess(
+    "zig", 
+    args = args, 
+    options = {poStdErrToStdOut, poUsePath, poParentStreams}
+  )
+  # Get the code so we can carry across the exit code
+  let exitCode = process.waitForExit()
+  # Clean up
+  close process
+  quit exitCode

--- a/src/zigcpp.nim
+++ b/src/zigcpp.nim
@@ -1,2 +1,3 @@
-import os, strutils
-discard execShellCmd "zig c++ " & commandLineParams().join(" ")
+import zigcc/utils
+
+callZig("c++")


### PR DESCRIPTION
Ran into two small problems

- Exit code wasn't carried across from zig so Nim didn't know if it failed
- If there was a space in my path then compilation would fail

This fixes those two problems by using `startProcess` instead so that each argument is set correctly and then quitting with the exit code when finished